### PR TITLE
Add precondition IIS modules

### DIFF
--- a/modules/InstallWebserverAgent.psm1
+++ b/modules/InstallWebserverAgent.psm1
@@ -45,11 +45,11 @@ Function Install-WebserverAgentModuleIIS([string]$InstallPath, [Boolean]$Use64Bi
 
 	if ($Use64Bit)
 	{
-		$arguments =  "install module /name:'Dynatrace Webserver Agent (64bit)' /image:'$InstallPath\agent\lib64\dtagent.dll' /add:true /lock:true"
+		$arguments =  "install module /name:'Dynatrace Webserver Agent (64bit)' /image:'$InstallPath\agent\lib64\dtagent.dll' /add:true /lock:true /preCondition:bitness64"
 	}
 	else
 	{
-		$arguments =  "install module /name:'Dynatrace Webserver Agent (32bit)' /image:'$InstallPath\agent\lib\dtagent.dll' /add:true /lock:true"
+		$arguments =  "install module /name:'Dynatrace Webserver Agent (32bit)' /image:'$InstallPath\agent\lib\dtagent.dll' /add:true /lock:true /preCondition:bitness32"
 	}
 
 	iex "$appcmd $arguments"


### PR DESCRIPTION
Preconditions bitness32/bitness64 should be used to make sure that IIS always loads correct version of module.

That is important on servers where you have both 32 and 64 bit application pools.

Other why you can see similar issues than we found on our PoC project: http://olli.problem.fi/2016/09/troubleshooting-performance-issues.html
